### PR TITLE
Add a flag to skip .so file strip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Usage: build.sh [-p PYTHON_VER] [-n NAME] [-r] [-h] [-v]
   -n NAME       : Name of the layer
   -r            : Raw mode, don't zip layer contents
   -d            : Don't install Python dependencies
+  -s            : Don't strip .so files
   -h            : Help
   -v            : Display build.sh version
 ```

--- a/_make.sh
+++ b/_make.sh
@@ -56,8 +56,10 @@ rm -rf pip*
 find . -type d -name "tests" -exec rm -rf {} +
 find . -type d -name "test" -exec rm -rf {} +
 find . -type d -name "__pycache__" -exec rm -rf {} +
-find -name "*.so" -not -path "*/PIL/*" | xargs strip
-find -name "*.so.*" -not -path "*/PIL/*" | xargs strip
+if [[ "$STRIP" == true ]]; then
+    find -name "*.so" -not -path "*/PIL/*" | xargs strip
+    find -name "*.so.*" -not -path "*/PIL/*" | xargs strip
+fi
 find . -name '*.pyc' -delete
 if [[ -f "/temp/build/_clean.sh" ]]; then
     echo "Running custom cleaning script"


### PR DESCRIPTION
This allows dependencies with compiled binaries, such as [psycopg2-binary](https://pypi.org/project/psycopg2-binary/) to work properly in the Lambda environment after building.

When the `.so` files are stripped, the Lambda function will fail with this exception:

```
[ERROR] Runtime.ImportModuleError: Unable to import module 'main': libpq-3d107b13.so.5.11: ELF load command address/offset not properly aligned
```

I've tested this change on my project and can confirm that it works as expected for my project.

I came to this conclusion by taking a look at [serverless-python-requirements](https://github.com/UnitedIncome/serverless-python-requirements) which provides this option and specifically mentions the `ELF load command` error I was receiving: https://github.com/UnitedIncome/serverless-python-requirements#option-not-to-strip-binaries

Also, thank you for this project! It has been very useful 😄 